### PR TITLE
feat: You can now use `MidiSynth.play` with a velocity.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,17 @@ only option. You can also specify its path in your `config.exs` (see
 
 Start IEx by running `iex -S mix` from a shell prompt.
 
-Now try playing a node. Notes are numbered sequentially. Middle C is note 60.
+Now try playing a note. Notes are numbered sequentially. Middle C is note 60.
 Here's how to play middle C for 100 ms.
 
 ```elixir
 iex> MidiSynth.play(60, 100)
+```
+
+You can play the same note with a different velocity. The velocities range from 1 to 127. Here's how to play middle C for 100 ms with velocity mezzo-forte: 80.
+
+```elixir
+iex> MidiSynth.play(60, 100, 80)
 ```
 
 If you don't like the piano, try switching the instrument to something else. For

--- a/lib/midi_synth.ex
+++ b/lib/midi_synth.ex
@@ -25,9 +25,12 @@ defmodule MidiSynth do
 
       iex> MidiSynth.play(60, 100)
       :ok
+
+      iex> MidiSynth.play(60, 100, 80)
+      :ok
   """
-  def play(note, duration) do
-    Worker.play(MidiSynth.Worker, {note, duration})
+  def play(note, duration, velocity \\ 127) do
+    Worker.play(MidiSynth.Worker, {note, duration, velocity})
   end
 
   @doc """

--- a/lib/midi_synth/worker.ex
+++ b/lib/midi_synth/worker.ex
@@ -23,8 +23,11 @@ defmodule MidiSynth.Worker do
     GenServer.cast(pid, {:midi, data})
   end
 
-  def play(pid, {note, duration}) when is_integer(note) and is_integer(duration) do
-    GenServer.cast(pid, {:play, {note, duration}})
+  def play(pid, {note, duration, velocity})
+      when is_integer(note) and
+             is_integer(duration) and
+             is_integer(velocity) do
+    GenServer.cast(pid, {:play, {note, duration, velocity}})
   end
 
   # gen_server callbacks
@@ -54,10 +57,9 @@ defmodule MidiSynth.Worker do
     {:noreply, state}
   end
 
-  def handle_cast({:play, {note, duration}}, state) do
-    send_midi(state, note_on(note, 127))
+  def handle_cast({:play, {note, duration, velocity}}, state) do
+    send_midi(state, note_on(note, velocity))
     Process.send_after(self(), {:midi, note_off(note)}, duration)
-
     {:noreply, state}
   end
 


### PR DESCRIPTION
You can now use `MidiSynth.play` with a velocity. Changed `MidiSynth.play/2` to `MidiSynth.play/3`, with a default velocity of 127 for backwards compatibility.